### PR TITLE
orientationを設定してプレビューが回転できないようにする

### DIFF
--- a/lib/focused_area_ocr_flutter.dart
+++ b/lib/focused_area_ocr_flutter.dart
@@ -3,6 +3,7 @@ import 'dart:ui' as ui;
 
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:focused_area_ocr_flutter/focused_area_ocr_painter.dart';
 import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
 
@@ -25,6 +26,7 @@ class FocusedAreaOCRView extends StatefulWidget {
     this.onCameraFeedReady,
     this.onDetectorViewModeChanged,
     this.onCameraLensDirectionChanged,
+    this.orientation,
   }) : super(key: key);
 
   final double? focusedAreaWidth;
@@ -41,6 +43,7 @@ class FocusedAreaOCRView extends StatefulWidget {
   final VoidCallback? onCameraFeedReady;
   final VoidCallback? onDetectorViewModeChanged;
   final Function(CameraLensDirection direction)? onCameraLensDirectionChanged;
+  final DeviceOrientation? orientation;
 
   @override
   State<FocusedAreaOCRView> createState() => _FocusedAreaOCRViewState();
@@ -101,20 +104,20 @@ class _FocusedAreaOCRViewState extends State<FocusedAreaOCRView> {
       enableAudio: false,
       imageFormatGroup: imageFormatGroup,
     );
-    _controller?.initialize().then((_) {
-      if (!mounted) {
-        return;
+    await _controller?.initialize();
+    await _controller?.lockCaptureOrientation(widget.orientation);
+    if (!mounted) {
+      return;
+    }
+    _controller?.startImageStream(_processCameraImage).then((value) {
+      if (widget.onCameraFeedReady != null) {
+        widget.onCameraFeedReady!();
       }
-      _controller?.startImageStream(_processCameraImage).then((value) {
-        if (widget.onCameraFeedReady != null) {
-          widget.onCameraFeedReady!();
-        }
-        if (widget.onCameraLensDirectionChanged != null) {
-          widget.onCameraLensDirectionChanged!(camera.lensDirection);
-        }
-      });
-      setState(() {});
+      if (widget.onCameraLensDirectionChanged != null) {
+        widget.onCameraLensDirectionChanged!(camera.lensDirection);
+      }
     });
+    setState(() {});
   }
 
   Future<void> _stopLiveFeed() async {

--- a/lib/focused_area_ocr_flutter.dart
+++ b/lib/focused_area_ocr_flutter.dart
@@ -109,14 +109,13 @@ class _FocusedAreaOCRViewState extends State<FocusedAreaOCRView> {
     if (!mounted) {
       return;
     }
-    _controller?.startImageStream(_processCameraImage).then((value) {
-      if (widget.onCameraFeedReady != null) {
-        widget.onCameraFeedReady!();
-      }
-      if (widget.onCameraLensDirectionChanged != null) {
-        widget.onCameraLensDirectionChanged!(camera.lensDirection);
-      }
-    });
+    await _controller?.startImageStream(_processCameraImage);
+    if (widget.onCameraFeedReady != null) {
+      widget.onCameraFeedReady!();
+    }
+    if (widget.onCameraLensDirectionChanged != null) {
+      widget.onCameraLensDirectionChanged!(camera.lensDirection);
+    }
     setState(() {});
   }
 


### PR DESCRIPTION
### やりたいこと
画面固定をしているがCameraのプレビューだけ回転を検知してしまい、固定する必要があった
`lockCaptureOrientation`を設定して固定できるようにする